### PR TITLE
Adding thread requirement to achievements

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -35,6 +35,28 @@ export default new ClientEvent("messageCreate", async (message) => {
 		}
 	}
 
+	if (message.channel === achievements) {
+	        if (message.channel.isThread()) return
+	
+	        const channel = message.channel as TextChannel
+	
+		if (message.type === MessageType.Reply) {
+			let msg = "<@" + message.author.id + "> your message has been deleted.\n\n"
+			msg += "Please keep conversations within threads.\n\n"
+			
+			let n = 30
+			const reply = await message.reply(msg + getEnding(n--))
+			await message.delete()
+			
+			await timedReply(reply, msg, n)
+			return
+		}
+
+	        const thread = await message.startThread()
+	        let msg = ":tada:"
+	        await thread.send(msg)
+    	}
+	
 	if (message.channel === bans) {
 		if (message.channel.isThread()) return
 


### PR DESCRIPTION
I have no way of testing this. I copied the exact format and logic of the automated bans moderation and modified it to open a new thread with the 🎉 reaction as the message. Discord automatically creates a thread title (when manually creating a thread) so I left it blank in this implementation. This will prevent users from replying to achievements with gifs in the main channel.